### PR TITLE
Fix deserialization of Geometries or Features nested in JSON

### DIFF
--- a/src/main/java/dev/goerner/geozen/jackson/GeoZenModule.java
+++ b/src/main/java/dev/goerner/geozen/jackson/GeoZenModule.java
@@ -29,12 +29,11 @@ import dev.goerner.geozen.jackson.serializer.MultiPointSerializer;
 import dev.goerner.geozen.jackson.serializer.MultiPolygonSerializer;
 import dev.goerner.geozen.jackson.serializer.PointSerializer;
 import dev.goerner.geozen.jackson.serializer.PolygonSerializer;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.module.SimpleModule;
 
 public class GeoZenModule extends SimpleModule {
 
-	public GeoZenModule(ObjectMapper objectMapper) {
+	public GeoZenModule() {
 		super("GeoZenModule");
 
 		addSerializer(Point.class, new PointSerializer());
@@ -47,15 +46,15 @@ public class GeoZenModule extends SimpleModule {
 		addSerializer(Feature.class, new FeatureSerializer());
 		addSerializer(FeatureCollection.class, new FeatureCollectionSerializer());
 
-		addDeserializer(Point.class, new PointDeserializer(objectMapper));
-		addDeserializer(LineString.class, new LineStringDeserializer(objectMapper));
-		addDeserializer(Polygon.class, new PolygonDeserializer(objectMapper));
-		addDeserializer(MultiPoint.class, new MultiPointDeserializer(objectMapper));
-		addDeserializer(MultiLineString.class, new MultiLineStringDeserializer(objectMapper));
-		addDeserializer(MultiPolygon.class, new MultiPolygonDeserializer(objectMapper));
-		addDeserializer(Geometry.class, new GeometryDeserializer(objectMapper));
-		addDeserializer(GeometryCollection.class, new GeometryCollectionDeserializer(objectMapper));
-		addDeserializer(Feature.class, new FeatureDeserializer(objectMapper));
-		addDeserializer(FeatureCollection.class, new FeatureCollectionDeserializer(objectMapper));
+		addDeserializer(Point.class, new PointDeserializer());
+		addDeserializer(LineString.class, new LineStringDeserializer());
+		addDeserializer(Polygon.class, new PolygonDeserializer());
+		addDeserializer(MultiPoint.class, new MultiPointDeserializer());
+		addDeserializer(MultiLineString.class, new MultiLineStringDeserializer());
+		addDeserializer(MultiPolygon.class, new MultiPolygonDeserializer());
+		addDeserializer(Geometry.class, new GeometryDeserializer());
+		addDeserializer(GeometryCollection.class, new GeometryCollectionDeserializer());
+		addDeserializer(Feature.class, new FeatureDeserializer());
+		addDeserializer(FeatureCollection.class, new FeatureCollectionDeserializer());
 	}
 }

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/AbstractGeometryDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/AbstractGeometryDeserializer.java
@@ -3,16 +3,9 @@ package dev.goerner.geozen.jackson.deserializer;
 import dev.goerner.geozen.model.Geometry;
 import dev.goerner.geozen.model.Position;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 
 public abstract class AbstractGeometryDeserializer<T extends Geometry> extends ValueDeserializer<T> {
-
-    protected final ObjectMapper objectMapper;
-
-    protected AbstractGeometryDeserializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     protected void checkType(JsonNode rootNode, String expectedType) {
 		String type = rootNode.get("type").asString();

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/FeatureCollectionDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/FeatureCollectionDeserializer.java
@@ -5,7 +5,6 @@ import dev.goerner.geozen.model.collections.FeatureCollection;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 
 import java.util.ArrayList;
@@ -13,15 +12,9 @@ import java.util.List;
 
 public class FeatureCollectionDeserializer extends ValueDeserializer<FeatureCollection> {
 
-    private final ObjectMapper objectMapper;
-
-    public FeatureCollectionDeserializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
 	public FeatureCollection deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		String type = rootNode.get("type").asString();
 		if (!type.equalsIgnoreCase("FeatureCollection")) {
@@ -32,7 +25,7 @@ public class FeatureCollectionDeserializer extends ValueDeserializer<FeatureColl
 
 		List<Feature> features = new ArrayList<>();
 		for (JsonNode featureNode : rootNode.get("features")) {
-			features.add((Feature) featureDeserializer.deserialize(featureNode.traverse(objectMapper._deserializationContext()), ctxt));
+			features.add((Feature) featureDeserializer.deserialize(featureNode.traverse(ctxt), ctxt));
 		}
 
 		return new FeatureCollection(features);

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/FeatureDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/FeatureDeserializer.java
@@ -5,7 +5,6 @@ import dev.goerner.geozen.model.Geometry;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 
 import java.util.HashMap;
@@ -13,15 +12,9 @@ import java.util.Map;
 
 public class FeatureDeserializer extends ValueDeserializer<Feature> {
 
-    private final ObjectMapper objectMapper;
-
-    public FeatureDeserializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
 	public Feature deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		String type = rootNode.get("type").asString();
 		if (!type.equalsIgnoreCase("Feature")) {
@@ -31,7 +24,7 @@ public class FeatureDeserializer extends ValueDeserializer<Feature> {
 		String id = rootNode.get("id").asString();
 
 		ValueDeserializer<?> geometryDeserializer = ctxt.findRootValueDeserializer(ctxt.constructType(Geometry.class));
-		Geometry geometry = (Geometry) geometryDeserializer.deserialize(rootNode.get("geometry").traverse(objectMapper._deserializationContext()), ctxt);
+		Geometry geometry = (Geometry) geometryDeserializer.deserialize(rootNode.get("geometry").traverse(ctxt), ctxt);
 
 		Map<String, String> properties = new HashMap<>();
         for (Map.Entry<String, JsonNode> property : rootNode.get("properties").properties()) {

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/GeometryCollectionDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/GeometryCollectionDeserializer.java
@@ -11,7 +11,6 @@ import dev.goerner.geozen.model.simple_geometry.Polygon;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 
 import java.util.ArrayList;
@@ -19,15 +18,9 @@ import java.util.List;
 
 public class GeometryCollectionDeserializer extends ValueDeserializer<GeometryCollection> {
 
-    private final ObjectMapper objectMapper;
-
-    public GeometryCollectionDeserializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
 	public GeometryCollection deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		String type = rootNode.get("type").asString();
 		if (!type.equalsIgnoreCase("GeometryCollection")) {
@@ -53,7 +46,7 @@ public class GeometryCollectionDeserializer extends ValueDeserializer<GeometryCo
 				case "MultiPolygon" -> multiPolygonSerializer;
 				default -> throw new IllegalArgumentException("Invalid GeoJSON type: " + type + ".");
 			};
-			geometries.add((Geometry) geometryDeserializer.deserialize(geometryNode.traverse(objectMapper._deserializationContext()), ctxt));
+			geometries.add((Geometry) geometryDeserializer.deserialize(geometryNode.traverse(ctxt), ctxt));
 		}
 
 		return new GeometryCollection(geometries);

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/GeometryDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/GeometryDeserializer.java
@@ -11,18 +11,13 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 
 public class GeometryDeserializer extends AbstractGeometryDeserializer<Geometry> {
 
-    public GeometryDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public Geometry deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 		String type = rootNode.get("type").asString();
 
 		JavaType javaType = switch (type) {
@@ -36,6 +31,6 @@ public class GeometryDeserializer extends AbstractGeometryDeserializer<Geometry>
 		};
 		ValueDeserializer<?> deserializer = ctxt.findRootValueDeserializer(javaType);
 
-		return (Geometry) deserializer.deserialize(rootNode.traverse(objectMapper._deserializationContext()), ctxt);
+		return (Geometry) deserializer.deserialize(rootNode.traverse(ctxt), ctxt);
 	}
 }

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/LineStringDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/LineStringDeserializer.java
@@ -5,20 +5,15 @@ import dev.goerner.geozen.model.Position;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class LineStringDeserializer extends AbstractGeometryDeserializer<LineString> {
 
-    public LineStringDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public LineString deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "LineString");
 

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiLineStringDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiLineStringDeserializer.java
@@ -5,20 +5,15 @@ import dev.goerner.geozen.model.Position;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class MultiLineStringDeserializer extends AbstractGeometryDeserializer<MultiLineString> {
 
-    public MultiLineStringDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public MultiLineString deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "MultiLineString");
 

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiPointDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiPointDeserializer.java
@@ -5,20 +5,15 @@ import dev.goerner.geozen.model.Position;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class MultiPointDeserializer extends AbstractGeometryDeserializer<MultiPoint> {
 
-    public MultiPointDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public MultiPoint deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "MultiPoint");
 

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiPolygonDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/MultiPolygonDeserializer.java
@@ -5,20 +5,15 @@ import dev.goerner.geozen.model.Position;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class MultiPolygonDeserializer extends AbstractGeometryDeserializer<MultiPolygon> {
 
-    public MultiPolygonDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public MultiPolygon deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "MultiPolygon");
 

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/PointDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/PointDeserializer.java
@@ -4,17 +4,12 @@ import dev.goerner.geozen.model.simple_geometry.Point;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 public class PointDeserializer extends AbstractGeometryDeserializer<Point> {
 
-    public PointDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public Point deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "Point");
 

--- a/src/main/java/dev/goerner/geozen/jackson/deserializer/PolygonDeserializer.java
+++ b/src/main/java/dev/goerner/geozen/jackson/deserializer/PolygonDeserializer.java
@@ -5,20 +5,15 @@ import dev.goerner.geozen.model.Position;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PolygonDeserializer extends AbstractGeometryDeserializer<Polygon> {
 
-    public PolygonDeserializer(ObjectMapper objectMapper) {
-        super(objectMapper);
-    }
-
     @Override
 	public Polygon deserialize(JsonParser p, DeserializationContext ctxt) {
-		JsonNode rootNode = objectMapper.readTree(p);
+		JsonNode rootNode = p.readValueAsTree();
 
 		checkType(rootNode, "Polygon");
 

--- a/src/test/java/dev/goerner/geozen/geojson/GeoJsonTest.java
+++ b/src/test/java/dev/goerner/geozen/geojson/GeoJsonTest.java
@@ -27,13 +27,43 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class GeoJsonTest {
 
+	// DTO record for testing nested geometry deserialization
+	public record LocationDTO(
+		String name,
+		Geometry location,
+		String dataSource
+	) {}
+
 	private static ObjectMapper objectMapper;
 
 	@BeforeAll
 	static void setup() {
         objectMapper = JsonMapper.builder()
-                .addModule(new GeoZenModule(new ObjectMapper()))
+                .addModule(new GeoZenModule())
                 .build();
+	}
+
+	@Test
+	public void testNestedPointDeserialization() {
+		String json = """
+			{
+			    "name": "Some JSON Object",
+			    "location": {
+			        "type": "Point",
+			        "coordinates": [9.123456, 45.987654]
+			    },
+			    "dataSource": "MANUAL"
+			}
+			""";
+
+		LocationDTO locationDTO = objectMapper.readValue(json, LocationDTO.class);
+
+		assertEquals("Some JSON Object", locationDTO.name());
+		assertInstanceOf(Point.class, locationDTO.location());
+		Point point = (Point) locationDTO.location();
+		assertEquals(9.123456, point.getLongitude());
+		assertEquals(45.987654, point.getLatitude());
+		assertEquals("MANUAL", locationDTO.dataSource());
 	}
 
 	@Test


### PR DESCRIPTION
This also removes the need to parse an ObjectMapper to GeoZenModule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified setup: the module can now be instantiated without parameters.
  * GeoJSON deserialization no longer requires a shared mapper, improving compatibility with default configurations and reducing coupling.
  * Streamlined parsing by using the parser/context directly for all geometry types.

* **Tests**
  * Added coverage for nested geometry scenarios to ensure reliable deserialization of embedded Point data within DTOs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->