### PR TITLE
Add CRS reprojection support for WGS_84 and WEB_MERCATOR

### DIFF
--- a/src/main/kotlin/dev/goerner/geozen/calc/AbstractDistanceCalculator.kt
+++ b/src/main/kotlin/dev/goerner/geozen/calc/AbstractDistanceCalculator.kt
@@ -1,5 +1,6 @@
 package dev.goerner.geozen.calc
 
+import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
 import dev.goerner.geozen.model.collections.GeometryCollection
@@ -39,7 +40,9 @@ abstract class AbstractDistanceCalculator : DistanceCalculator {
      * @throws UnsupportedOperationException if the geometry type combination is unsupported
      */
     override fun calculate(g1: Geometry, g2: Geometry): Double {
-        val (a, b) = if (geometryOrdinal(g1) <= geometryOrdinal(g2)) g1 to g2 else g2 to g1
+        val r1 = g1.reprojectTo(CoordinateReferenceSystem.WGS_84)
+        val r2 = g2.reprojectTo(CoordinateReferenceSystem.WGS_84)
+        val (a, b) = if (geometryOrdinal(r1) <= geometryOrdinal(r2)) r1 to r2 else r2 to r1
         return when (a) {
             is Point if b is Point -> calculate(a, b)
             is Point if b is LineString -> calculate(a, b)

--- a/src/main/kotlin/dev/goerner/geozen/model/Geometry.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/Geometry.kt
@@ -32,4 +32,6 @@ abstract class Geometry(open val coordinateReferenceSystem: CoordinateReferenceS
      * @return The exact distance to the other [Geometry].
      */
     abstract fun exactDistanceTo(other: Geometry): Double
+
+    abstract fun reprojectTo(crs: CoordinateReferenceSystem): Geometry
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/Reprojector.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/Reprojector.kt
@@ -1,0 +1,42 @@
+package dev.goerner.geozen.model
+
+import kotlin.math.atan
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.tan
+
+internal object Reprojector {
+
+    private const val EARTH_RADIUS_METERS = 6378137.0
+    private const val WEB_MERCATOR_MAX_LATITUDE = 85.051129
+
+    fun reproject(pos: Position, fromCrs: CoordinateReferenceSystem, toCrs: CoordinateReferenceSystem): Position =
+        when (toCrs) {
+            CoordinateReferenceSystem.WGS_84 -> toWgs84(pos, fromCrs)
+            CoordinateReferenceSystem.WEB_MERCATOR -> toWebMercator(pos, fromCrs)
+        }
+
+    private fun toWgs84(pos: Position, crs: CoordinateReferenceSystem): Position = when (crs) {
+        CoordinateReferenceSystem.WGS_84 -> pos
+        CoordinateReferenceSystem.WEB_MERCATOR -> Position(
+            Math.toDegrees(pos.longitude / EARTH_RADIUS_METERS),
+            Math.toDegrees(2.0 * atan(exp(pos.latitude / EARTH_RADIUS_METERS)) - Math.PI / 2.0),
+            pos.altitude
+        )
+    }
+
+    private fun toWebMercator(pos: Position, crs: CoordinateReferenceSystem): Position = when (crs) {
+        CoordinateReferenceSystem.WEB_MERCATOR -> pos
+        CoordinateReferenceSystem.WGS_84 -> {
+            require(pos.latitude in -WEB_MERCATOR_MAX_LATITUDE..WEB_MERCATOR_MAX_LATITUDE) {
+                "Latitude ${pos.latitude} is outside the valid range for Web Mercator " +
+                        "[-$WEB_MERCATOR_MAX_LATITUDE, $WEB_MERCATOR_MAX_LATITUDE]"
+            }
+            Position(
+                EARTH_RADIUS_METERS * Math.toRadians(pos.longitude),
+                EARTH_RADIUS_METERS * ln(tan(Math.PI / 4.0 + Math.toRadians(pos.latitude) / 2.0)),
+                pos.altitude
+            )
+        }
+    }
+}

--- a/src/main/kotlin/dev/goerner/geozen/model/collections/GeometryCollection.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/collections/GeometryCollection.kt
@@ -28,4 +28,11 @@ data class GeometryCollection(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else GeometryCollection(
+            geometries.map { it.reprojectTo(crs) },
+            crs
+        )
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiLineString.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiLineString.kt
@@ -5,7 +5,7 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
-
+import dev.goerner.geozen.model.Reprojector
 
 
 /**
@@ -36,4 +36,13 @@ data class MultiLineString(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else MultiLineString(
+            coordinates.map { lineString ->
+                lineString.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) }
+            },
+            crs
+        )
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPoint.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPoint.kt
@@ -5,6 +5,8 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
+import dev.goerner.geozen.model.simple_geometry.LineString
 
 /**
  * A [MultiPoint] is a [Geometry] that represents a collection of [Positions][Position] in space. It is
@@ -20,4 +22,11 @@ data class MultiPoint(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else LineString(
+            coordinates.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) },
+            crs
+        )
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPoint.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPoint.kt
@@ -6,7 +6,6 @@ import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
 import dev.goerner.geozen.model.Reprojector
-import dev.goerner.geozen.model.simple_geometry.LineString
 
 /**
  * A [MultiPoint] is a [Geometry] that represents a collection of [Positions][Position] in space. It is
@@ -25,7 +24,7 @@ data class MultiPoint(
 
     override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
         if (coordinateReferenceSystem == crs) this
-        else LineString(
+        else MultiPoint(
             coordinates.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) },
             crs
         )

--- a/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPolygon.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/multi_geometry/MultiPolygon.kt
@@ -5,6 +5,7 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
 
 /**
  * A [MultiPolygon] is a [Geometry] that represents a collection of [Polygons][dev.goerner.geozen.model.simple_geometry.Polygon] in space. It is
@@ -50,4 +51,15 @@ data class MultiPolygon(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else MultiPolygon(
+            coordinates.map { polygon ->
+                polygon.map { ring ->
+                    ring.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) }
+                }
+            },
+            crs
+        )
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/LineString.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/LineString.kt
@@ -5,6 +5,7 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
 
 /**
  * A [LineString] is a [Geometry] that represents a sequence of [Positions][Position] in space. It is
@@ -30,4 +31,11 @@ data class LineString(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else LineString(
+            coordinates.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) },
+            crs
+        )
 }

--- a/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/Point.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/Point.kt
@@ -5,6 +5,7 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
 
 /**
  * A [Point] is a [Geometry] that represents a single position in space. It is defined by a single
@@ -30,6 +31,13 @@ data class Point(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else Point(
+            Reprojector.reproject(coordinates, coordinateReferenceSystem, crs),
+            crs
+        )
 
     val longitude: Double
         get() = this.coordinates.longitude

--- a/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/Polygon.kt
+++ b/src/main/kotlin/dev/goerner/geozen/model/simple_geometry/Polygon.kt
@@ -5,6 +5,7 @@ import dev.goerner.geozen.calc.PreciseDistanceCalculator
 import dev.goerner.geozen.model.CoordinateReferenceSystem
 import dev.goerner.geozen.model.Geometry
 import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
 
 /**
  * A [Polygon] is a [Geometry] that represents an area in space. It is defined by a list of
@@ -51,6 +52,15 @@ data class Polygon(
 
     override fun exactDistanceTo(other: Geometry): Double =
         PreciseDistanceCalculator.calculate(this, other)
+
+    override fun reprojectTo(crs: CoordinateReferenceSystem): Geometry =
+        if (coordinateReferenceSystem == crs) this
+        else Polygon(
+            coordinates.map { ring ->
+                ring.map { Reprojector.reproject(it, coordinateReferenceSystem, crs) }
+            },
+            crs
+        )
 
     val exteriorRing: List<Position>
         get() = this.coordinates[0]

--- a/src/test/kotlin/dev/goerner/geozen/calc/WebMercatorDistanceTest.kt
+++ b/src/test/kotlin/dev/goerner/geozen/calc/WebMercatorDistanceTest.kt
@@ -1,0 +1,189 @@
+package dev.goerner.geozen.calc
+
+import dev.goerner.geozen.model.CoordinateReferenceSystem
+import dev.goerner.geozen.model.Position
+import dev.goerner.geozen.model.Reprojector
+import dev.goerner.geozen.model.simple_geometry.LineString
+import dev.goerner.geozen.model.simple_geometry.Point
+import dev.goerner.geozen.model.simple_geometry.Polygon
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+/**
+ * Verifies that distance calculations produce the same results regardless of whether the input
+ * geometries use WGS 84 or Web Mercator coordinates. Both calculators share the same reprojection
+ * step in [AbstractDistanceCalculator], so tests run against both.
+ *
+ * Strategy: take geometry pairs whose WGS 84 distances are already established by
+ * [ApproximateDistanceCalculatorTest] / [PreciseDistanceCalculatorTest], reproject the same
+ * coordinates to Web Mercator, and assert the results match within floating-point rounding.
+ */
+class WebMercatorDistanceTest : FunSpec({
+
+    val distanceTolerance = 0.01 // meters – accounts for double round-trip rounding
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fun Position.toWm(): Position = Reprojector.reproject(
+        this, CoordinateReferenceSystem.WGS_84,
+        CoordinateReferenceSystem.WEB_MERCATOR
+    )
+
+    // Reference WGS84 positions (shared across tests)
+    val wgsA = Position(11.4694, 49.2965)
+    val wgsB = Position(11.0549, 49.4532)
+    val wgsC = Position(11.4432, 49.3429)
+    val wgsD = Position(11.4463, 49.1877)
+    val wgsE = Position(11.5161, 49.1239)
+
+    val wgsPolygonExterior = listOf(
+        Position(11.5, 49.3),
+        Position(11.6, 49.3),
+        Position(11.6, 49.4),
+        Position(11.5, 49.4),
+        Position(11.5, 49.3)
+    )
+    val wgsInsidePoint = Position(11.55, 49.35)
+
+    // Reprojected Web Mercator equivalents
+    val wmA = wgsA.toWm()
+    val wmB = wgsB.toWm()
+    val wmC = wgsC.toWm()
+    val wmD = wgsD.toWm()
+    val wmE = wgsE.toWm()
+    val wmPolygonExterior = wgsPolygonExterior.map { it.toWm() }
+    val wmInsidePoint = wgsInsidePoint.toWm()
+
+    // ── ApproximateDistanceCalculator ─────────────────────────────────────────
+
+    context("ApproximateDistanceCalculator") {
+
+        test("Point to Point - both Web Mercator") {
+            //given
+            val p1 = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val p2 = Point(wmB, CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = ApproximateDistanceCalculator.calculate(p1, p2)
+
+            //then
+            distance shouldBe (34701.39385602524 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Point - mixed CRS") {
+            //given
+            val p1 = Point(wgsA)
+            val p2 = Point(wmB, CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = ApproximateDistanceCalculator.calculate(p1, p2)
+
+            //then
+            distance shouldBe (34701.39385602524 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to LineString - both Web Mercator") {
+            //given
+            val p = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val lineString = LineString(listOf(wmC, wmD, wmE), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = ApproximateDistanceCalculator.calculate(p, lineString)
+
+            //then
+            distance shouldBe (1832.5414860629317 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Polygon - point outside, both Web Mercator") {
+            //given
+            val point = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val polygon = Polygon(listOf(wmPolygonExterior), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = ApproximateDistanceCalculator.calculate(point, polygon)
+
+            //then
+            distance shouldBe (2252.7607736674404 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Polygon - point inside, both Web Mercator") {
+            //given
+            val point = Point(wmInsidePoint, CoordinateReferenceSystem.WEB_MERCATOR)
+            val polygon = Polygon(listOf(wmPolygonExterior), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = ApproximateDistanceCalculator.calculate(point, polygon)
+
+            //then
+            distance shouldBe 0.0
+        }
+    }
+
+    // ── PreciseDistanceCalculator ─────────────────────────────────────────────
+
+    context("PreciseDistanceCalculator") {
+
+        test("Point to Point - both Web Mercator") {
+            //given
+            val p1 = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val p2 = Point(wmB, CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = PreciseDistanceCalculator.calculate(p1, p2)
+
+            //then
+            distance shouldBe (34782.42347014982 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Point - mixed CRS") {
+            //given
+            val p1 = Point(wgsA)
+            val p2 = Point(wmB, CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = PreciseDistanceCalculator.calculate(p1, p2)
+
+            //then
+            distance shouldBe (34782.42347014982 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to LineString - both Web Mercator") {
+            //given
+            val p = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val lineString = LineString(listOf(wmC, wmD, wmE), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = PreciseDistanceCalculator.calculate(p, lineString)
+
+            //then
+            distance shouldBe (1837.9808889683015 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Polygon - point outside, both Web Mercator") {
+            //given
+            val point = Point(wmA, CoordinateReferenceSystem.WEB_MERCATOR)
+            val polygon = Polygon(listOf(wmPolygonExterior), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = PreciseDistanceCalculator.calculate(point, polygon)
+
+            //then
+            distance shouldBe (2259.4399787892717 plusOrMinus distanceTolerance)
+        }
+
+        test("Point to Polygon - point inside, both Web Mercator") {
+            //given
+            val point = Point(wmInsidePoint, CoordinateReferenceSystem.WEB_MERCATOR)
+            val polygon = Polygon(listOf(wmPolygonExterior), CoordinateReferenceSystem.WEB_MERCATOR)
+
+            //when
+            val distance = PreciseDistanceCalculator.calculate(point, polygon)
+
+            //then
+            distance shouldBe 0.0
+        }
+    }
+})
+
+

--- a/src/test/kotlin/dev/goerner/geozen/model/ReprojectorTest.kt
+++ b/src/test/kotlin/dev/goerner/geozen/model/ReprojectorTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 class ReprojectorTest : FunSpec({
 
@@ -19,7 +20,7 @@ class ReprojectorTest : FunSpec({
         val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WGS_84)
 
         //then
-        result shouldBe pos
+        result shouldBeSameInstanceAs pos
     }
 
     test("Web Mercator to Web Mercator returns same Position instance") {
@@ -30,7 +31,7 @@ class ReprojectorTest : FunSpec({
         val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WEB_MERCATOR)
 
         //then
-        result shouldBe pos
+        result shouldBeSameInstanceAs pos
     }
 
     // ── WGS84 → Web Mercator ─────────────────────────────────────────────────

--- a/src/test/kotlin/dev/goerner/geozen/model/ReprojectorTest.kt
+++ b/src/test/kotlin/dev/goerner/geozen/model/ReprojectorTest.kt
@@ -1,0 +1,164 @@
+package dev.goerner.geozen.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+class ReprojectorTest : FunSpec({
+
+    val tolerance = 1e-6
+
+    // ── Identity ─────────────────────────────────────────────────────────────
+
+    test("WGS84 to WGS84 returns same Position instance") {
+        //given
+        val pos = Position(11.0, 48.0, 100.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WGS_84)
+
+        //then
+        result shouldBe pos
+    }
+
+    test("Web Mercator to Web Mercator returns same Position instance") {
+        //given
+        val pos = Position(1223685.0, 6140770.0, 100.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WEB_MERCATOR)
+
+        //then
+        result shouldBe pos
+    }
+
+    // ── WGS84 → Web Mercator ─────────────────────────────────────────────────
+
+    test("WGS84 origin maps to Web Mercator origin") {
+        //given
+        val pos = Position(0.0, 0.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+
+        //then
+        result.longitude shouldBe (0.0 plusOrMinus tolerance)
+        result.latitude shouldBe (0.0 plusOrMinus tolerance)
+    }
+
+    test("WGS84 to Web Mercator known value") {
+        //given
+        // lon=11.0°, lat=0.0° (equatorial): x = 6378137 * toRadians(11), y = 0
+        val pos = Position(11.0, 0.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+
+        //then
+        result.longitude shouldBe (1224514.3987260093 plusOrMinus 0.001)
+        result.latitude shouldBe (0.0 plusOrMinus 0.001)
+    }
+
+    test("WGS84 to Web Mercator preserves altitude") {
+        //given
+        val pos = Position(11.0, 48.0, 500.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+
+        //then
+        result.altitude shouldBe 500.0
+    }
+
+    test("WGS84 to Web Mercator rejects latitude above 85.051129") {
+        //given
+        val pos = Position(0.0, 85.051130)
+
+        //when / then
+        shouldThrow<IllegalArgumentException> {
+            Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+        }
+    }
+
+    test("WGS84 to Web Mercator rejects latitude below -85.051129") {
+        //given
+        val pos = Position(0.0, -85.051130)
+
+        //when / then
+        shouldThrow<IllegalArgumentException> {
+            Reprojector.reproject(pos, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+        }
+    }
+
+    // ── Web Mercator → WGS84 ─────────────────────────────────────────────────
+
+    test("Web Mercator origin maps to WGS84 origin") {
+        //given
+        val pos = Position(0.0, 0.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WGS_84)
+
+        //then
+        result.longitude shouldBe (0.0 plusOrMinus tolerance)
+        result.latitude shouldBe (0.0 plusOrMinus tolerance)
+    }
+
+    test("Web Mercator to WGS84 known value") {
+        //given
+        // x = 6378137 * toRadians(11) ≈ 1224514.399, y = 0  →  lon=11°, lat=0°
+        val pos = Position(1224514.3987260093, 0.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WGS_84)
+
+        //then
+        result.longitude shouldBe (11.0 plusOrMinus tolerance)
+        result.latitude shouldBe (0.0 plusOrMinus tolerance)
+    }
+
+    test("Web Mercator to WGS84 preserves altitude") {
+        //given
+        val pos = Position(0.0, 0.0, 250.0)
+
+        //when
+        val result = Reprojector.reproject(pos, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WGS_84)
+
+        //then
+        result.altitude shouldBe 250.0
+    }
+
+    // ── Round-trips ──────────────────────────────────────────────────────────
+
+    test("WGS84 to Web Mercator round-trip") {
+        //given
+        val original = Position(11.0, 48.0, 100.0)
+
+        //when
+        val webMercator = Reprojector.reproject(original, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+        val roundTrip = Reprojector.reproject(webMercator, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WGS_84)
+
+        //then
+        roundTrip.longitude shouldBe (original.longitude plusOrMinus tolerance)
+        roundTrip.latitude shouldBe (original.latitude plusOrMinus tolerance)
+        roundTrip.altitude shouldBe original.altitude
+    }
+
+    test("Web Mercator to WGS84 round-trip") {
+        //given
+        val original = Position(1223685.1096, 6106854.8349, 100.0)
+
+        //when
+        val wgs84 = Reprojector.reproject(original, CoordinateReferenceSystem.WEB_MERCATOR, CoordinateReferenceSystem.WGS_84)
+        val roundTrip = Reprojector.reproject(wgs84, CoordinateReferenceSystem.WGS_84, CoordinateReferenceSystem.WEB_MERCATOR)
+
+        //then
+        roundTrip.longitude shouldBe (original.longitude plusOrMinus tolerance)
+        roundTrip.latitude shouldBe (original.latitude plusOrMinus tolerance)
+        roundTrip.altitude shouldBe original.altitude
+    }
+})
+
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geometry types now support reprojection between WGS 84 and Web Mercator; distance calculations automatically reproject inputs for consistent results.
  * Public geometry API extended to expose reprojection capability.

* **Tests**
  * Added comprehensive tests validating reprojection correctness and that distance results match across coordinate systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->